### PR TITLE
Update docker-compose command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Make sure all of them are available before starting playing with the examples in
 Lets start Vault and PostgreSQL, with:
 
 ``` bash
-docker-compose up
+docker-compose up -d
 ```
 
 And then you can already run the boostrap script:


### PR DESCRIPTION
If it is not necessary to show logs from DB or Vault, I suggest to run `docker-compose up -d` instead, which will run the containers as deamons (in the background).